### PR TITLE
Container locator customizations

### DIFF
--- a/src/ContainerLocator.php
+++ b/src/ContainerLocator.php
@@ -14,11 +14,25 @@ class ContainerLocator implements HandlerLocator
     protected $container;
 
     /**
-     * @param Container $container
+     * @var string
      */
-    public function __construct(Container $container)
+    private $origin;
+
+    /**
+     * @var string
+     */
+    private $target;
+
+    /**
+     * @param Container $container
+     * @param string    $origin
+     * @param string    $target
+     */
+    public function __construct(Container $container, $origin = 'Jobs', $target = 'Listeners')
     {
         $this->container = $container;
+        $this->origin    = $origin;
+        $this->target    = $target;
     }
 
     /**
@@ -28,7 +42,7 @@ class ContainerLocator implements HandlerLocator
      */
     public function getHandlerForCommand($commandName)
     {
-        $handlerName = str_replace('Jobs', 'Listeners', $commandName);
+        $handlerName = str_replace($this->origin, $this->target, $commandName);
 
         if (!class_exists($handlerName)) {
             throw MissingHandlerException::forCommand($commandName);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -25,9 +25,16 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->mergeConfigFrom($configPath, 'tactician');
 
         $this->app->bind(CommandHandlerMiddleware::class, function () {
+            /** @var \Illuminate\Contracts\Config\Repository $config */
+            $config = $this->app['config'];
+
             return new CommandHandlerMiddleware(
                 new ClassNameExtractor(),
-                new ContainerLocator($this->app),
+                new ContainerLocator(
+                    $this->app,
+                    $config->get('tactician.replacements.origin', 'Jobs'),
+                    $config->get('tactician.replacements.target', 'Listeners')
+                ),
                 new HandleInflector()
             );
         });

--- a/src/config/tactician.php
+++ b/src/config/tactician.php
@@ -20,4 +20,22 @@ return [
         TransactionMiddleware::class,
         CommandHandlerMiddleware::class,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Replacements
+    |--------------------------------------------------------------------------
+    |
+    | The ContainerLocator provided by this package will match your commands
+    | to your handlers by replacing part of the command namespace.
+    |
+    | Use this config to customize what to look in the Command namespace and
+    | what to replace it with.
+    |
+    */
+
+    'replacements' => [
+        'origin' => 'Jobs',
+        'target' => 'Listeners',
+    ]
 ];

--- a/tests/ContainerLocatorTest.php
+++ b/tests/ContainerLocatorTest.php
@@ -32,4 +32,12 @@ class ContainerLocatorTest extends TestCase
 
         $this->assertInstanceOf(Dummies\Nested\Listeners\Foo::class, $handler);
     }
+
+    public function testCanHaveCustomOriginAndTargetFolders()
+    {
+        $locator = new ContainerLocator(new Container(), 'Commands', 'Handlers');
+        $handler = $locator->getHandlerForCommand('Madewithlove\Tactician\Dummies\Commands\Foo');
+
+        $this->assertInstanceOf(Dummies\Handlers\Foo::class, $handler);
+    }
 }

--- a/tests/Dummies/Commands/Foo.php
+++ b/tests/Dummies/Commands/Foo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Madewithlove\Tactician\Dummies\Commands;
+
+class Foo
+{
+
+}

--- a/tests/Dummies/Handlers/Foo.php
+++ b/tests/Dummies/Handlers/Foo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Madewithlove\Tactician\Dummies\Handlers;
+
+class Foo
+{
+
+}


### PR DESCRIPTION
With this PR we can allow different string replacements on the ContainerLocator, simplifying a small customization without the need to reimplement the whole class and rebind the middleware.

Tested changes on ContainerLocator, SP doesn't have tests but change does not break backwards compat. Config should be republished but defaults work anyway.
